### PR TITLE
Mazo finito y con probabilidades

### DIFF
--- a/repository/IngSoft2-Model/Board.class.st
+++ b/repository/IngSoft2-Model/Board.class.st
@@ -12,7 +12,7 @@ Board class >> withSpaces: amountOfSpaces Laps: amountOfLaps [
 	^ self new
 		initializeWithSpaces: amountOfSpaces
 		laps: amountOfLaps
-		effect: (Array with: (NoEffect withProbability: 1))
+		effect: {(ProbabilityWrapper with: NoEffect new probability: 1)}
 ]
 
 { #category : #'instance creation - old' }
@@ -26,10 +26,10 @@ Board class >> withSpaces: anInteger Laps: numberOfLaps effects: arrayOfEffects 
 { #category : #initialization }
 Board >> generateBoardWithSpaces: amountOfSpaces laps: amountOfLaps effect: arrayOfEffects [
 	| arrayOfShuffledEffects count |
-	self padEffects: arrayOfEffects.
 	board := OrderedCollection new.
 	arrayOfShuffledEffects := ProbabilityDistributor new
-		createArrayWith: arrayOfEffects
+		createShuffledCollection: arrayOfEffects
+		defaultElement: NoEffect new
 		size: amountOfLaps * amountOfSpaces.
 	count := 1.
 	1 to: amountOfLaps do: [ :lap | 
@@ -70,8 +70,7 @@ Board >> howFarFromStart: aLocker [
 
 { #category : #initialization }
 Board >> initializeWithSpaces: amountOfSpaces laps: amountOfLaps effect: arrayOfEffects [
-	((self validateSpaces: amountOfSpaces andLaps: amountOfLaps)
-		or: (self validateEffectProbabilities: arrayOfEffects))
+	(self validateSpaces: amountOfSpaces andLaps: amountOfLaps)
 		ifTrue: [ CreationError
 				signal: 'You cannot create a board with invalid values' ]
 		ifFalse: [ self
@@ -85,22 +84,9 @@ Board >> lastLocker [
 	^board last 
 ]
 
-{ #category : #initialization }
-Board >> padEffects: arrayOfEffects [
-	arrayOfEffects
-		add:
-			(NoEffect
-				withProbability: 1 - (arrayOfEffects sum: [ :anEffect | anEffect probability ]))
-]
-
 { #category : #accessing }
 Board >> startingLocker [
 	^ board first.
-]
-
-{ #category : #verification }
-Board >> validateEffectProbabilities: aSumOfEffectProbailities [ 
-	 ^(aSumOfEffectProbailities sum: [ :anObject | anObject probability ]) > 1
 ]
 
 { #category : #initialization }

--- a/repository/IngSoft2-Model/Deck.class.st
+++ b/repository/IngSoft2-Model/Deck.class.st
@@ -7,17 +7,25 @@ Class {
 	#category : #'IngSoft2-Model'
 }
 
+{ #category : #instantiation }
+Deck class >> with: aCollectionOfCards [
+	^ self new initializeWithCards: aCollectionOfCards
+]
+
 { #category : #'instance creation' }
 Deck class >> withCards: aCollectionOfCards [ 
 	^self new initializeWithCards: aCollectionOfCards
 ]
 
 { #category : #accessing }
+Deck >> cardsLeft [
+	^ deck size
+]
+
+{ #category : #accessing }
 Deck >> drawCard [
-	| topCard |
-	topCard := deck first.
-	self shuffle.
-	^ topCard
+	deck isEmpty ifTrue:[MissingCardError signal: 'No more cards in the deck'].
+	^ deck removeFirst
 ]
 
 { #category : #initialization }
@@ -25,7 +33,19 @@ Deck >> initializeWithCards: aCollectionOfCards [
 	deck := aCollectionOfCards asOrderedCollection.
 ]
 
+{ #category : #'as yet unclassified' }
+Deck >> putAtBottom: aCard [  
+	deck addLast: aCard
+]
+
 { #category : #shuffling }
 Deck >> shuffle [
 	deck shuffle
+]
+
+{ #category : #merging }
+Deck >> shuffleWith: aDeck [ 
+	aDeck cardsLeft timesRepeat: [ self putAtBottom: aDeck drawCard ].
+	^self shuffle
+	 
 ]

--- a/repository/IngSoft2-Model/Game.class.st
+++ b/repository/IngSoft2-Model/Game.class.st
@@ -12,12 +12,15 @@ Class {
 }
 
 { #category : #initialization }
-Game class >> withBoard: aBoard dice: aDie players: somePlayers [ 
+Game class >> withBoard: aBoard dice: aDie players: somePlayers [
+	| cards |
+	cards := OrderedCollection new.
+	somePlayers size * 2 timesRepeat: [ cards add: NoEffectCard new ].
 	^ self new
 		initializeWithBoard: aBoard
 		dice: aDie
 		players: somePlayers
-		cards: (Deck withCards: (Array with: NoEffectCard new)).
+		cards: (Deck with: cards)
 ]
 
 { #category : #'instance creation' }
@@ -77,7 +80,7 @@ Game >> applyRedoCard: aRedoCard [
 { #category : #'card application' }
 Game >> applyRepeatCar: aPlayer [
    turnManager specialTurn: aPlayer.
-	self lastEffectApplied applyTo: self.
+	lastEffectApplied applyTo: self.
 	turnManager endSpecialTurn: aPlayer.
 	
 ]

--- a/repository/IngSoft2-Model/GameEffect.class.st
+++ b/repository/IngSoft2-Model/GameEffect.class.st
@@ -7,11 +7,6 @@ Class {
 	#category : #'IngSoft2-Model'
 }
 
-{ #category : #probability }
-GameEffect class >> withProbability: aFloat [
-	^ self new initializeWithProbability: aFloat
-]
-
 { #category : #comparing }
 GameEffect >> = otherEffect [
 	^self class == otherEffect class

--- a/repository/IngSoft2-Model/Locker.class.st
+++ b/repository/IngSoft2-Model/Locker.class.st
@@ -11,7 +11,7 @@ Class {
 
 { #category : #'instance creation' }
 Locker class >> position: lockerNumber  lap: lapNumber [ 
-	^ self new initializeWithPosition: lockerNumber lap: lapNumber effect: (NoEffect withProbability: 1).
+	^ self new initializeWithPosition: lockerNumber lap: lapNumber effect: NoEffect new.
 ]
 
 { #category : #'instance creation' }

--- a/repository/IngSoft2-Model/MoonWalkEffect.class.st
+++ b/repository/IngSoft2-Model/MoonWalkEffect.class.st
@@ -7,9 +7,9 @@ Class {
 	#category : #'IngSoft2-Model'
 }
 
-{ #category : #'instance creation' }
-MoonWalkEffect class >> withProbability: anInteger goBack: anInteger2 [
-	^ self new initializeWithProbability: anInteger goBack: anInteger2
+{ #category : #instantiation }
+MoonWalkEffect class >> goBack: anInteger [
+	^ self new goBack: anInteger
 ]
 
 { #category : #apply }
@@ -22,8 +22,7 @@ MoonWalkEffect >> backingSpaces [
 	^stepsBack 
 ]
 
-{ #category : #initialization }
-MoonWalkEffect >> initializeWithProbability: anInteger goBack: anInteger2 [ 
-	probability := anInteger.
-	stepsBack := anInteger2.
+{ #category : #initializarion }
+MoonWalkEffect >> goBack: anInteger [
+	stepsBack := anInteger
 ]

--- a/repository/IngSoft2-Model/ProbabilityDistributor.class.st
+++ b/repository/IngSoft2-Model/ProbabilityDistributor.class.st
@@ -9,16 +9,34 @@ ProbabilityDistributor >> createArrayWith: aCollection size: length [
 	^self createShuffledCollection: aCollection size: length.
 ]
 
+{ #category : #instantiation }
+ProbabilityDistributor >> createShuffledCollection: aCollection defaultElement: defaultElement size: anInteger [
+	| paddedCollection totalProbability |
+	paddedCollection := aCollection asOrderedCollection.
+	totalProbability := aCollection
+		sum: [ :aProbableObject | aProbableObject probability ].
+	totalProbability <= 1
+		ifTrue: [ paddedCollection
+				add:
+					(ProbabilityWrapper
+						with: defaultElement
+						probability: (1 - totalProbability round: 3)) ]
+		ifFalse: [ CreationError signal: 'Probability over 1' ].
+	^ self createShuffledCollection: paddedCollection size: anInteger
+]
+
 { #category : #creation }
-ProbabilityDistributor >> createShuffledCollection: aCollection size: length [
-	"Recieves a collection of objects that understand #probability and returns a shuffled OrderedCollection distributed with the probability of each object"
+ProbabilityDistributor >> createShuffledCollection: probableObjects size: length [
+	"Recieves a collection of probable objects with element and probability"
 
 	| result |
 	result := OrderedCollection new.
-	aCollection
-		do: [ :anObject | 
+	probableObjects
+		do: [ :aProbableObject | 
 			result
-				add: anObject
-				withOccurrences: (anObject probability * length) truncated ].
+				add: aProbableObject element
+				withOccurrences: (aProbableObject probability * length) truncated ].
+	result size = length
+		ifFalse: [ result add: probableObjects last element ].
 	^ result shuffle
 ]

--- a/repository/IngSoft2-Model/ProbabilityWrapper.class.st
+++ b/repository/IngSoft2-Model/ProbabilityWrapper.class.st
@@ -1,0 +1,35 @@
+Class {
+	#name : #ProbabilityWrapper,
+	#superclass : #Object,
+	#instVars : [
+		'object',
+		'probability'
+	],
+	#category : #'IngSoft2-Model'
+}
+
+{ #category : #instantiation }
+ProbabilityWrapper class >> with: anObject probability: aProbability [
+	^ self new initializeWith: anObject probability: aProbability
+]
+
+{ #category : #access }
+ProbabilityWrapper >> element [
+	^ object
+]
+
+{ #category : #initialization }
+ProbabilityWrapper >> initializeWith: anObject probability: aProbability [ 
+	object := anObject.
+	probability := aProbability.
+]
+
+{ #category : #access }
+ProbabilityWrapper >> probability [
+	^ probability
+]
+
+{ #category : #access }
+ProbabilityWrapper >> value [
+	^ object
+]

--- a/repository/IngSoft2-Tests/BoardTest.class.st
+++ b/repository/IngSoft2-Tests/BoardTest.class.st
@@ -11,8 +11,8 @@ BoardTest >> testBoardWithProbabilityMoreThanOneHundredFails [
 				withSpaces: 10
 				Laps: 1
 				effects:
-					{(NoEffect withProbability: 0.6).
-					(WormHoleEffect withProbability: 0.5)} ]
+					{(ProbabilityWrapper with: AtomicBombEffect new probability: 0.6).
+					(ProbabilityWrapper with: WormHoleEffect new probability: 0.5)} ]
 		raise: CreationError
 ]
 
@@ -22,7 +22,7 @@ BoardTest >> testCreateBoardWithNoEffects [
 	board := Board
 		withSpaces: 3
 		Laps: 2
-		effects: {(NoEffect withProbability: 1)}.
+		effects: {ProbabilityWrapper with: NoEffect new probability: 1}.
 	starting := board startingLocker.
 	6
 		timesRepeat:
@@ -37,7 +37,7 @@ BoardTest >> testCreateBoardWithNoEffectsByDefault [
 	board := Board
 		withSpaces: 10
 		Laps: 10
-		effects: {(WormHoleEffect withProbability: 0.15)}.
+		effects: {(ProbabilityWrapper with: WormHoleEffect new probability: 0.15)}.
 	starting := board startingLocker.
 	result := OrderedCollection new.
 	counter := 0.
@@ -58,8 +58,8 @@ BoardTest >> testCreateBoardWithSeveralEffects [
 		withSpaces: 2
 		Laps: 1
 		effects:
-			{(NoEffect withProbability: 0.5).
-			(WormHoleEffect withProbability: 0.5)}.
+			{(ProbabilityWrapper with: NoEffect new probability: 0.5).
+			(ProbabilityWrapper with: WormHoleEffect new probability: 0.5)}.
 	starting := board startingLocker.
 	result := OrderedCollection new.
 	counter := 0.
@@ -80,8 +80,8 @@ BoardTest >> testDistribiutionOfEffects [
 		withSpaces: 10
 		Laps: 10
 		effects:
-			{(WormHoleEffect withProbability: 0.15).
-			(AtomicBombEffect withProbability: 0.02)}.
+			{(ProbabilityWrapper with: AtomicBombEffect new probability: 0.02).
+			(ProbabilityWrapper with: WormHoleEffect new probability: 0.15)}.
 	starting := board startingLocker.
 	result := OrderedCollection new.
 	counter := 0.

--- a/repository/IngSoft2-Tests/DeckOfCardsTest.class.st
+++ b/repository/IngSoft2-Tests/DeckOfCardsTest.class.st
@@ -4,23 +4,69 @@ Class {
 	#category : #'IngSoft2-Tests'
 }
 
-{ #category : #setup }
-DeckOfCardsTest >> drawOneHundredCardsFrom: aDeck [ 
+{ #category : #drawing }
+DeckOfCardsTest >> draw: amount from: aDeck [ 
 	| result |
 	result := OrderedCollection new.
-	100 timesRepeat: [ result add: aDeck drawCard ].
+	amount timesRepeat: [ result add: aDeck drawCard ].
 	^ result
+]
+
+{ #category : #probability }
+DeckOfCardsTest >> elements: elements probability: probabilities amount: amount [
+	| result index |
+	result := OrderedCollection new.
+	index := 1.
+	elements size
+		timesRepeat: [ result
+				add:
+					(ProbabilityWrapper
+						with: (elements at: index)
+						probability: (probabilities at: index)).
+			index := index + 1 ].
+	^ ProbabilityDistributor new
+		createShuffledCollection: result
+		size: amount
 ]
 
 { #category : #tests }
 DeckOfCardsTest >> testDrawCardsWithUniformDistribution [
-	|deckOfCards result|
-	deckOfCards := Deck withCards: (Array with: NoEffectCard new with: OverloadCard new).
-	
-	
-	result := self drawOneHundredCardsFrom: deckOfCards.
-	self assert: (result anySatisfy:[:aCard | aCard = NoEffectCard new]).
-	self assert: (result anySatisfy:[:aCard | aCard = OverloadCard new]).
+	| deckOfCards result cardDistribution |
+	cardDistribution := self
+		elements:
+			{NoEffectCard new.
+			OverloadCard new}
+		probability: {0.4 . 0.6}
+		amount: 100.
+	deckOfCards := Deck with: cardDistribution.
+	result := self draw: 100 from: deckOfCards.
+	self
+		assert: (result count: [ :card | NoEffectCard new = card ])
+		equals: 40.
+	self
+		assert: (result count: [ :card | OverloadCard new = card ])
+		equals: 60
+]
 
+{ #category : #tests }
+DeckOfCardsTest >> testDrawFiniteAmountOrCards [
+	| cardDistribuiton deckOfCards result |
+	cardDistribuiton := self elements: { NoEffectCard new . OverloadCard new } probability: { (0.5) . (0.5) } amount: 10.
+	deckOfCards := Deck with: cardDistribuiton.
+	result := self draw: 10 from: deckOfCards.
+	self assert: result size equals: 10.
+	self should: [ deckOfCards drawCard ] raise: MissingCardError
+]
 
+{ #category : #tests }
+DeckOfCardsTest >> testMergeAnEmptyDeckWithAnother [
+	| cardDistribuiton deckOfCards emptyDeck |
+	cardDistribuiton := self elements: { NoEffectCard new . OverloadCard new } probability: { (0.5) . (0.5) } amount: 10.
+	deckOfCards := Deck with: cardDistribuiton.
+	emptyDeck := Deck with: {}.
+	
+	emptyDeck shuffleWith: deckOfCards.
+
+	self assert: emptyDeck cardsLeft equals: 10.
+	self assert: deckOfCards cardsLeft equals: 0.
 ]

--- a/repository/IngSoft2-Tests/GameTest.class.st
+++ b/repository/IngSoft2-Tests/GameTest.class.st
@@ -1,8 +1,30 @@
 Class {
 	#name : #GameTest,
 	#superclass : #TestCase,
+	#instVars : [
+		'playerOne',
+		'playerTwo',
+		'playerThree'
+	],
 	#category : #'IngSoft2-Tests'
 }
+
+{ #category : #probability }
+GameTest >> elements: elements probability: probabilities amount: amount [
+	| result index |
+	result := OrderedCollection new.
+	index := 1.
+	elements size
+		timesRepeat: [ result
+				add:
+					(ProbabilityWrapper
+						with: (elements at: index)
+						probability: (probabilities at: index)).
+			index := index + 1 ].
+	^ ProbabilityDistributor new
+		createShuffledCollection: result
+		size: amount
+]
 
 { #category : #setup }
 GameTest >> fede [
@@ -17,6 +39,14 @@ GameTest >> glenn [
 { #category : #setup }
 GameTest >> nicky [
 	^ 'Nicky'
+]
+
+{ #category : #running }
+GameTest >> setUp [
+	"Hooks that subclasses may override to define the fixture of test."
+	playerOne := 'Fede'.
+	playerTwo := 'Glenn'.
+	playerThree := 'Nicky'.
 ]
 
 { #category : #tests }
@@ -44,7 +74,7 @@ GameTest >> testAtomicBombEffect [
 	board := Board
 		withSpaces: 2
 		Laps: 3
-		effects: {(AtomicBombEffect withProbability: 1)}.
+		effects: {(ProbabilityWrapper with: AtomicBombEffect new probability: 1)}.
 	game := Game withBoard: board dice: die players: {playerOne}.
 	game play: playerOne.
 	self
@@ -61,7 +91,7 @@ GameTest >> testAtomicBombEffectWithAnotherPlayerInStartingPosition [
 	board := Board
 		withSpaces: 5
 		Laps: 2
-		effects: {(AtomicBombEffect withProbability: 1)}.
+		effects: {(ProbabilityWrapper with: AtomicBombEffect new probability: 1)}.
 	game := Game
 		withBoard: board
 		dice: die
@@ -79,18 +109,17 @@ GameTest >> testAtomicBombEffectWithAnotherPlayerInStartingPosition [
 
 { #category : #tests }
 GameTest >> testCancellationCard [
-	| board playerOne die game deckOfCards playerTwo cancellationCard |
+	| board playerOne die game deckOfCards playerTwo cancellationCard cards |
 	die := LoadedDie withValue: 1.
 	playerOne := self fede.
 	playerTwo := self glenn.
-	deckOfCards := Deck
-		withCards:
-			{SpeedCard new.
-			CancellationCard new}.
+	cards := self
+		elements: {SpeedCard new . CancellationCard new} probability: {0.5 . 0.5} amount: 30.
+	deckOfCards := Deck with: cards.
 	board := Board
 		withSpaces: 100
 		Laps: 1
-		effects: {(DrawCardEffect withProbability: 1)}.
+		effects: {(ProbabilityWrapper with: DrawCardEffect new probability: 1)}.
 	game := Game
 		withBoard: board
 		dice: die
@@ -120,11 +149,12 @@ GameTest >> testCancellationCardWithNoPermanentCardsActive [
 	| board playerOne die game deckOfCards cancellation |
 	die := LoadedDie withValue: 1.
 	playerOne := self fede.
-	deckOfCards := Deck withCards: {CancellationCard new}.
+	deckOfCards := Deck
+		with: (self elements: {CancellationCard new} probability: {0.5} amount: 30).
 	board := Board
 		withSpaces: 10
 		Laps: 1
-		effects: {(DrawCardEffect withProbability: 1)}.
+		effects: {(ProbabilityWrapper with: DrawCardEffect new probability: 1)}.
 	game := Game
 		withBoard: board
 		dice: die
@@ -138,18 +168,17 @@ GameTest >> testCancellationCardWithNoPermanentCardsActive [
 
 { #category : #tests }
 GameTest >> testCancellationCardWithTwoEqualActiveEffects [
-	| board playerOne die game deckOfCards playerTwo |
+	| board playerOne die game deckOfCards playerTwo cards |
 	die := LoadedDie withValue: 1.
 	playerOne := self fede.
 	playerTwo := self glenn.
-	deckOfCards := Deck
-		withCards:
-			{SpeedCard new.
-			CancellationCard new}.
+	cards := self
+		elements: {SpeedCard new . CancellationCard new} probability: {0.5 . 0.5} amount: 30.
+	deckOfCards := Deck with: cards.
 	board := Board
 		withSpaces: 100
 		Laps: 1
-		effects: {(DrawCardEffect withProbability: 1)}.
+		effects: {(ProbabilityWrapper with: DrawCardEffect new probability: 1)}.
 	game := Game
 		withBoard: board
 		dice: die
@@ -180,7 +209,7 @@ GameTest >> testCannotPlayCardThatIsNotInHand [
 	| board playerOne die game deckOfCards |
 	die := LoadedDie withValue: 2.
 	playerOne := self fede.
-	deckOfCards := Deck withCards: {NoEffectCard new}.
+	deckOfCards := Deck with: {NoEffectCard new . NoEffectCard new}.
 	board := Board withSpaces: 5 Laps: 1.
 	game := Game
 		withBoard: board
@@ -198,7 +227,12 @@ GameTest >> testCannotPlayPermanentCardOutOfTurn [
 	die := LoadedDie withValue: 2.
 	playerOne := self fede.
 	playerTwo := self glenn.
-	deckOfCards := Deck withCards: {AccelerationCard new}.
+	deckOfCards := Deck
+		with:
+			{AccelerationCard new.
+			AccelerationCard new.
+			AccelerationCard new.
+			AccelerationCard new}.
 	board := Board withSpaces: 5 Laps: 1.
 	game := Game
 		withBoard: board
@@ -232,18 +266,21 @@ GameTest >> testDrawCardEffect [
 	| board playerOne die game deckOfCards |
 	die := LoadedDie withValue: 2.
 	playerOne := self fede.
-	deckOfCards := Deck withCards: {NoEffectCard new}.
+	deckOfCards := Deck
+		with:
+			{NoEffectCard new.
+			NoEffectCard new.
+			NoEffectCard new}.
 	board := Board
 		withSpaces: 5
 		Laps: 1
-		effects: {(DrawCardEffect withProbability: 1)}.
+		effects: {(ProbabilityWrapper with: DrawCardEffect new probability: 1)}.
 	game := Game
 		withBoard: board
 		dice: die
 		players: {playerOne}
 		cards: deckOfCards.
 	game play: playerOne.
-	
 	self assert: (game checkHandOf: playerOne) size equals: 3
 ]
 
@@ -274,7 +311,7 @@ GameTest >> testHandOutTwoCardsInitially [
 	die := LoadedDie withValue: 5.
 	playerOne := self fede.
 	board := Board withSpaces: 10 Laps: 2.
-	deckOfCards := Deck withCards: {NoEffectCard new}.
+	deckOfCards := Deck withCards: {NoEffectCard new . NoEffectCard new}.
 	game := Game
 		withBoard: board
 		dice: die
@@ -292,7 +329,7 @@ GameTest >> testMoonWalkEffect [
 	board := Board
 		withSpaces: 10
 		Laps: 1
-		effects: {(MoonWalkEffect withProbability: 1 goBack: 2)}.
+		effects: {(ProbabilityWrapper with: (MoonWalkEffect goBack: 2) probability: 1)}.
 	game := Game
 		withBoard: board
 		dice: die
@@ -317,7 +354,7 @@ GameTest >> testNoEffect [
 	board := Board
 		withSpaces: 10
 		Laps: 1
-		effects: {(NoEffect withProbability: 1)}.
+		effects: {(ProbabilityWrapper with: NoEffect new probability: 1)}.
 	game := Game withBoard: board dice: die players: {playerOne}.
 	game play: playerOne.
 	self
@@ -330,7 +367,7 @@ GameTest >> testPlayCard [
 	| board playerOne die game deckOfCards |
 	die := LoadedDie withValue: 2.
 	playerOne := self fede.
-	deckOfCards := Deck withCards: {NoEffectCard new}.
+	deckOfCards := Deck with: {NoEffectCard new . NoEffectCard new}.
 	board := Board withSpaces: 5 Laps: 1.
 	game := Game
 		withBoard: board
@@ -348,7 +385,12 @@ GameTest >> testPlayCardAcceleration [
 	die := LoadedDie withValue: 2.
 	playerOne := self fede.
 	playerTwo := self glenn.
-	deckOfCards := Deck withCards: {AccelerationCard new}.
+	deckOfCards := Deck
+		with:
+			{AccelerationCard new.
+			AccelerationCard new.
+			AccelerationCard new.
+			AccelerationCard new}.
 	board := Board withSpaces: 5 Laps: 1.
 	game := Game
 		withBoard: board
@@ -374,7 +416,12 @@ GameTest >> testPlayOverloadCard [
 	die := LoadedDie withValue: 5.
 	playerOne := self fede.
 	playerTwo := self glenn.
-	deckOfCards := Deck withCards: {OverloadCard new}.
+	deckOfCards := Deck
+		with:
+			{OverloadCard new.
+			OverloadCard new.
+			OverloadCard new.
+			OverloadCard new}.
 	board := Board withSpaces: 6 Laps: 2.
 	game := Game
 		withBoard: board
@@ -400,7 +447,12 @@ GameTest >> testPlaySpeedCard [
 	die := LoadedDie withValue: 2.
 	playerOne := self fede.
 	playerTwo := self glenn.
-	deckOfCards := Deck withCards: {SpeedCard new}.
+	deckOfCards := Deck
+		with:
+			{SpeedCard new.
+			SpeedCard new.
+			SpeedCard new.
+			SpeedCard new}.
 	board := Board withSpaces: 5 Laps: 1.
 	game := Game
 		withBoard: board
@@ -422,17 +474,15 @@ GameTest >> testPlaySpeedCard [
 
 { #category : #tests }
 GameTest >> testPlayWithSeveralCards [
-	| board playerOne die game deckOfCards finalHand |
+	| board playerOne die game deckOfCards finalHand cards |
 	die := LoadedDie withValue: 1.
-	deckOfCards := Deck
-		withCards:
-			{NoEffectCard new.
-			OverloadCard new}.
+	cards := self elements: {NoEffectCard new . OverloadCard new} probability: {0.5 . 0.5} amount: 100.
+	deckOfCards := Deck with: cards.
 	playerOne := self fede.
 	board := Board
 		withSpaces: 100
 		Laps: 1
-		effects: {(DrawCardEffect withProbability: 1)}.
+		effects: {(ProbabilityWrapper with: DrawCardEffect new probability: 1)}.
 	game := Game
 		withBoard: board
 		dice: die
@@ -542,23 +592,28 @@ GameTest >> testPlayingWithTurnsWithThreePlayers [
 
 { #category : #tests }
 GameTest >> testRedoInstantCard [
-	| board playerOne die game deckOfCards playerTwo |
+	| board playerOne die game deckOfCards playerTwo cards |
 	die := LoadedDie withValue: 1.
 	playerOne := self fede.
 	playerTwo := self glenn.
-	deckOfCards := Deck
-		withCards:
+	cards := self
+		elements:
 			{RedoCard new.
 			CancellationCard new.
-			SpeedCard new}.
+			SpeedCard new}
+		probability: {0.4 . 0.3 . 0.3}
+		amount: 300.
+	deckOfCards := Deck with: cards.
 	board := Board
 		withSpaces: 100
 		Laps: 1
-		effects: {(DrawCardEffect withProbability: 1)}.
+		effects: {(ProbabilityWrapper with: DrawCardEffect new probability: 1)}.
 	game := Game
 		withBoard: board
 		dice: die
-		players: (Array with: playerOne with: playerTwo)
+		players:
+			{playerOne.
+			playerTwo}
 		cards: deckOfCards.
 	15
 		timesRepeat: [ game play: playerOne.
@@ -582,18 +637,19 @@ GameTest >> testRedoInstantCard [
 
 { #category : #tests }
 GameTest >> testRedoPermanentCard [
-	| board playerOne die game deckOfCards playerTwo redoCard |
+	| board die game deckOfCards redoCard cards |
 	die := LoadedDie withValue: 1.
-	playerOne := self fede.
-	playerTwo := self glenn.
-	deckOfCards := Deck
-		withCards:
+	cards := self
+		elements:
 			{SpeedCard new.
-			RedoCard new}.
+			RedoCard new}
+		probability: {0.5 . 0.5}
+		amount: 30.
+	deckOfCards := Deck with: cards.
 	board := Board
 		withSpaces: 100
 		Laps: 1
-		effects: {(DrawCardEffect withProbability: 1)}.
+		effects: {(ProbabilityWrapper with: DrawCardEffect new probability: 1)}.
 	game := Game
 		withBoard: board
 		dice: die
@@ -620,18 +676,19 @@ GameTest >> testRedoPermanentCard [
 
 { #category : #tests }
 GameTest >> testRedoPermanentCardOverload [
-	| board playerOne die game deckOfCards playerTwo redoCard |
+	| board die game deckOfCards redoCard cards |
 	die := LoadedDie withValue: 1.
-	playerOne := self fede.
-	playerTwo := self glenn.
-	deckOfCards := Deck
-		withCards:
+	cards := self
+		elements:
 			{OverloadCard new.
-			RedoCard new}.
+			RedoCard new}
+		probability: {0.5 . 0.5}
+		amount: 50.
+	deckOfCards := Deck with: cards.
 	board := Board
 		withSpaces: 100
 		Laps: 1
-		effects: {(DrawCardEffect withProbability: 1)}.
+		effects: {(ProbabilityWrapper with: DrawCardEffect new probability: 1)}.
 	game := Game
 		withBoard: board
 		dice: die
@@ -658,15 +715,17 @@ GameTest >> testRedoPermanentCardOverload [
 
 { #category : #tests }
 GameTest >> testRepeatMoonWalkEffect [
-	| board playerOne die game deckOfCards playerTwo |
+	| board die game deckOfCards cards |
 	die := LoadedDie withValue: 8.
-	playerOne := self fede.
-	playerTwo := self glenn.
-	deckOfCards := Deck withCards: {RepeatCard new}.
+	cards := self
+		elements: {RepeatCard new}
+		probability: {0.5}
+		amount: 50.
+	deckOfCards := Deck with: cards.
 	board := Board
 		withSpaces: 100
 		Laps: 1
-		effects: {(MoonWalkEffect withProbability: 1 goBack: 4)}.
+		effects: {(ProbabilityWrapper with: (MoonWalkEffect goBack: 2) probability: 1)}.
 	game := Game
 		withBoard: board
 		dice: die
@@ -679,23 +738,25 @@ GameTest >> testRepeatMoonWalkEffect [
 	game playCard: (RepeatCard new target: playerOne) from: playerOne.
 	self
 		assert: (game positionOf: playerOne)
-		equals: (Locker position: 5 lap: 1).
+		equals: (Locker position: 7 lap: 1 effect: MoonWalkEffect new).
 	self
 		assert: (game positionOf: playerTwo)
-		equals: (Locker position: 5 lap: 1)
+		equals: (Locker position: 7 lap: 1 effect: MoonWalkEffect new)
 ]
 
 { #category : #tests }
 GameTest >> testRepeatSpeedupEffect [
-	| board playerOne die game deckOfCards playerTwo |
+	| board die game deckOfCards cards |
 	die := LoadedDie withValue: 1.
-	playerOne := self fede.
-	playerTwo := self glenn.
-	deckOfCards := Deck withCards: {RepeatCard new}.
+	cards := self
+		elements: {RepeatCard new}
+		probability: {0.5}
+		amount: 50.
+	deckOfCards := Deck with: cards.
 	board := Board
 		withSpaces: 100
 		Laps: 1
-		effects: {(SpeedUpEffect withProbability: 1)}.
+		effects: {(ProbabilityWrapper with: SpeedUpEffect new probability: 1)}.
 	game := Game
 		withBoard: board
 		dice: die
@@ -715,13 +776,12 @@ GameTest >> testRepeatSpeedupEffect [
 
 { #category : #tests }
 GameTest >> testSpeedUpEffect [
-	| board playerOne die game |
+	| board die game |
 	die := LoadedDie withValue: 1.
-	playerOne := self fede.
 	board := Board
 		withSpaces: 10
 		Laps: 1
-		effects: {(SpeedUpEffect withProbability: 1)}.
+		effects: {(ProbabilityWrapper with: SpeedUpEffect new probability: 1)}.
 	game := Game withBoard: board dice: die players: {playerOne}.
 	game play: playerOne.
 	self
@@ -731,15 +791,17 @@ GameTest >> testSpeedUpEffect [
 
 { #category : #tests }
 GameTest >> testTargetTwoCardAtAPlayer [
-	| board playerOne die game deckOfCards playerTwo |
+	| board die game deckOfCards cards |
 	die := LoadedDie withValue: 1.
-	playerOne := self fede.
-	playerTwo := self glenn.
-	deckOfCards := Deck withCards: {SpeedCard new}.
+	cards := self
+		elements: {SpeedCard new}
+		probability: {1}
+		amount: 50.
+	deckOfCards := Deck with: cards.
 	board := Board
 		withSpaces: 100
 		Laps: 1
-		effects: {(DrawCardEffect withProbability: 1)}.
+		effects: {(ProbabilityWrapper with: DrawCardEffect new probability: 1)}.
 	game := Game
 		withBoard: board
 		dice: die
@@ -767,7 +829,7 @@ GameTest >> testWormHoleEffect [
 	board := Board
 		withSpaces: 10
 		Laps: 1
-		effects: {(WormHoleEffect withProbability: 1)}.
+		effects: {(ProbabilityWrapper with: WormHoleEffect new probability: 1)}.
 	game := Game withBoard: board dice: die players: {playerOne}.
 	game play: playerOne.
 	self
@@ -783,7 +845,7 @@ GameTest >> testWormHoleEffectLimitMove [
 	board := Board
 		withSpaces: 10
 		Laps: 1
-		effects: {(WormHoleEffect withProbability: 1)}.
+		effects: {(ProbabilityWrapper with: WormHoleEffect new probability: 1)}.
 	game := Game withBoard: board dice: die players: {playerOne}.
 	game play: playerOne.
 	self

--- a/repository/IngSoft2-Tests/ProbabilityDistributorTest.class.st
+++ b/repository/IngSoft2-Tests/ProbabilityDistributorTest.class.st
@@ -1,0 +1,42 @@
+Class {
+	#name : #ProbabilityDistributorTest,
+	#superclass : #TestCase,
+	#category : #'IngSoft2-Tests'
+}
+
+{ #category : #tests }
+ProbabilityDistributorTest >> testGetDistributedArrayOfObjects [
+	| result distributor |
+	distributor := ProbabilityDistributor new
+		createShuffledCollection:
+			{(ProbabilityWrapper with: 'Fede' probability: 0.4).
+			(ProbabilityWrapper with: 'Abril' probability: 0.6)}
+		size: 100.
+	self
+		assert: (distributor count: [ :name | 'Fede' == name ])
+		equals: 40.
+	self
+		assert: (distributor count: [ :name | 'Abril' == name ])
+		equals: 60
+]
+
+{ #category : #tests }
+ProbabilityDistributorTest >> testGetDistributedArrayOfObjectsPadded [
+	| result distributor |
+	distributor := ProbabilityDistributor new
+		createShuffledCollection:
+			{(ProbabilityWrapper with: 'Fede' probability: 0.4).
+			(ProbabilityWrapper with: 'Abril' probability: 0.4)}
+		defaultElement: ''
+		size: 100.
+	self assert: distributor size equals: 100.
+	self
+		assert: (distributor count: [ :name | 'Fede' == name ])
+		equals: 40.
+	self
+		assert: (distributor count: [ :name | 'Abril' == name ])
+		equals: 40.
+	self
+		assert: (distributor count: [ :name | '' == name ])
+		equals: 20
+]


### PR DESCRIPTION
1. Refactor de los efectos para desacoplarlos de sus probabilidades.
2. Generalice el ProbabilityDistributor para usarlo en las cartas y en los efectos.
3. Board ya no se encarga de las probabilidades, delega las validaciones y demás al Probability distributor.
4. Creación de setUp para limpiar tests y algunos refactors.
5. Creación de tests de probabilityDistributor.

Se podría desacoplar el probability distributor del board dejando la creacion de los lockers afuera del mismo pero no estoy seguro de que sea el mejor encare.